### PR TITLE
trim all path descriptions

### DIFF
--- a/build/lib/openapi/OpenAPIBundler.js
+++ b/build/lib/openapi/OpenAPIBundler.js
@@ -56,7 +56,10 @@ var OpenAPIBundler = /** @class */ (function () {
                     case 5:
                         content = _b.sent();
                         console.log('Injecting the endpoint names');
-                        return [2 /*return*/, JSON.parse(JSON.stringify(this.pathEndpointInjection(content)))];
+                        content = this.pathEndpointInjection(content);
+                        console.log('Trimming multi-line descriptions');
+                        content = this.trimMethodDescriptions(content);
+                        return [2 /*return*/, JSON.parse(JSON.stringify(content))];
                 }
             });
         });
@@ -308,6 +311,24 @@ var OpenAPIBundler = /** @class */ (function () {
         apiObject.endpoints = _.uniq(_.map(apiObject.paths, 'endpointName'));
         return apiObject;
     };
+    /**
+     * Trim description fields from path methods
+     * @param obj
+     * @param recurse
+     * @return apiObject
+     */
+    OpenAPIBundler.prototype.trimMethodDescriptions = function (apiObject, recurse) {
+        if (recurse === void 0) { recurse = false; }
+        _.each(apiObject.paths, function (pathObject) {
+            _.each(pathObject, function (methodObject) {
+                if (methodObject === null || methodObject === void 0 ? void 0 : methodObject.description) {
+                    methodObject.description = methodObject.description.trim();
+                }
+            });
+        });
+        return apiObject;
+    };
+    ;
     return OpenAPIBundler;
 }());
 exports["default"] = new OpenAPIBundler();

--- a/src/lib/openapi/OpenAPIBundler.ts
+++ b/src/lib/openapi/OpenAPIBundler.ts
@@ -51,9 +51,12 @@ class OpenAPIBundler {
     content = await this.bundleObject(content);
 
     console.log('Injecting the endpoint names');
-    return JSON.parse(JSON.stringify(
-      this.pathEndpointInjection(content),
-    ));
+    content = this.pathEndpointInjection(content);
+
+    console.log('Trimming multi-line descriptions');
+    content = this.trimMethodDescriptions(content);
+
+    return JSON.parse(JSON.stringify(content));
   }
 
   /**
@@ -257,6 +260,24 @@ class OpenAPIBundler {
     apiObject.endpoints = _.uniq(_.map(apiObject.paths, 'endpointName'));
     return apiObject;
   }
+
+  /**
+   * Trim description fields from path methods
+   * @param obj
+   * @param recurse
+   * @return apiObject
+   */
+  public trimMethodDescriptions (apiObject: any, recurse: boolean = false) {
+    _.each(apiObject.paths, (pathObject: any) => {
+      _.each(pathObject, (methodObject: any) => {
+        if (methodObject?.description) {
+          methodObject.description = methodObject.description.trim();
+        }
+      })
+    });
+
+    return apiObject;
+  };
 }
 
 export default new OpenAPIBundler();


### PR DESCRIPTION
closes https://github.com/acrontum/openapi-nodegen-typescript-server/issues/5

Trim descriptions in nunjuks templates for routes and domains, removing the trailing newline that appears in doxy comments

This solution will parse and trim route->method->descriptions from the parsed yaml file.