### PR TITLE
[FEATURE] infer success status code

### DIFF
--- a/build/lib/template/helpers/__tests__/getSingleSuccessResponse.js
+++ b/build/lib/template/helpers/__tests__/getSingleSuccessResponse.js
@@ -1,0 +1,197 @@
+"use strict";
+exports.__esModule = true;
+var tslib_1 = require("tslib");
+var getSingleSuccessResponse_1 = tslib_1.__importDefault(require("../getSingleSuccessResponse"));
+var responseObject = {
+    description: 'description',
+    schema: {
+        type: 'object',
+        properties: {
+            id: { type: 'string', description: 'id' },
+            text: { type: 'string', description: 'text' },
+            url: { type: 'string', description: 'url' }
+        }
+    }
+};
+var buildResponses = function (codes) {
+    return (codes || []).reduce(function (responses, code) {
+        var _a;
+        return Object.assign(responses, (_a = {},
+            _a[typeof code === 'number' ? code : "" + code] = responseObject,
+            _a));
+    }, {});
+};
+var asStrings = function (codes) { return (codes || []).map(String); };
+describe('getSingleSuccessResponse helper', function () {
+    it('can extract 200-level codes', function () { return tslib_1.__awaiter(void 0, void 0, void 0, function () {
+        var testCodes, apiObj, responseCode;
+        return tslib_1.__generator(this, function (_a) {
+            testCodes = [
+                [100, 200, 300, 400, 500],
+                [100, 201, 300, 400, 500],
+                [202, 500],
+                [203],
+                [204],
+                [205, 100],
+                [500, 206],
+            ];
+            apiObj = buildResponses(testCodes[0]);
+            responseCode = getSingleSuccessResponse_1["default"](apiObj);
+            expect(responseCode).toBe(200);
+            apiObj = buildResponses(asStrings(testCodes[0]));
+            responseCode = getSingleSuccessResponse_1["default"](apiObj);
+            expect(responseCode).toBe(200);
+            apiObj = buildResponses(testCodes[1]);
+            responseCode = getSingleSuccessResponse_1["default"](apiObj);
+            expect(responseCode).toBe(201);
+            apiObj = buildResponses(asStrings(testCodes[1]));
+            responseCode = getSingleSuccessResponse_1["default"](apiObj);
+            expect(responseCode).toBe(201);
+            apiObj = buildResponses(testCodes[2]);
+            responseCode = getSingleSuccessResponse_1["default"](apiObj);
+            expect(responseCode).toBe(202);
+            apiObj = buildResponses(asStrings(testCodes[2]));
+            responseCode = getSingleSuccessResponse_1["default"](apiObj);
+            expect(responseCode).toBe(202);
+            apiObj = buildResponses(testCodes[3]);
+            responseCode = getSingleSuccessResponse_1["default"](apiObj);
+            expect(responseCode).toBe(203);
+            apiObj = buildResponses(asStrings(testCodes[3]));
+            responseCode = getSingleSuccessResponse_1["default"](apiObj);
+            expect(responseCode).toBe(203);
+            apiObj = buildResponses(testCodes[4]);
+            responseCode = getSingleSuccessResponse_1["default"](apiObj);
+            expect(responseCode).toBe(204);
+            apiObj = buildResponses(asStrings(testCodes[4]));
+            responseCode = getSingleSuccessResponse_1["default"](apiObj);
+            expect(responseCode).toBe(204);
+            apiObj = buildResponses(testCodes[5]);
+            responseCode = getSingleSuccessResponse_1["default"](apiObj);
+            expect(responseCode).toBe(205);
+            apiObj = buildResponses(asStrings(testCodes[5]));
+            responseCode = getSingleSuccessResponse_1["default"](apiObj);
+            expect(responseCode).toBe(205);
+            apiObj = buildResponses(testCodes[6]);
+            responseCode = getSingleSuccessResponse_1["default"](apiObj);
+            expect(responseCode).toBe(206);
+            apiObj = buildResponses(asStrings(testCodes[6]));
+            responseCode = getSingleSuccessResponse_1["default"](apiObj);
+            expect(responseCode).toBe(206);
+            return [2 /*return*/];
+        });
+    }); });
+    it('returns nothing when there are multiple 200-level codes', function () { return tslib_1.__awaiter(void 0, void 0, void 0, function () {
+        var testCodes, apiObj, responseCode;
+        return tslib_1.__generator(this, function (_a) {
+            testCodes = [
+                [100, 200, 201, 300, 400, 500],
+                [100, 201, 202, 300, 400, 500],
+                [202, 203, 500],
+                [203, 204],
+                [204, 205],
+                [205, 204],
+                [206, 205, 100],
+                [500, 418, 200, 206],
+            ];
+            apiObj = buildResponses(testCodes[0]);
+            responseCode = getSingleSuccessResponse_1["default"](apiObj);
+            expect(responseCode).toBe(undefined);
+            apiObj = buildResponses(asStrings(testCodes[0]));
+            responseCode = getSingleSuccessResponse_1["default"](apiObj);
+            expect(responseCode).toBe(undefined);
+            apiObj = buildResponses(testCodes[1]);
+            responseCode = getSingleSuccessResponse_1["default"](apiObj);
+            expect(responseCode).toBe(undefined);
+            apiObj = buildResponses(asStrings(testCodes[1]));
+            responseCode = getSingleSuccessResponse_1["default"](apiObj);
+            expect(responseCode).toBe(undefined);
+            apiObj = buildResponses(testCodes[2]);
+            responseCode = getSingleSuccessResponse_1["default"](apiObj);
+            expect(responseCode).toBe(undefined);
+            apiObj = buildResponses(asStrings(testCodes[2]));
+            responseCode = getSingleSuccessResponse_1["default"](apiObj);
+            expect(responseCode).toBe(undefined);
+            apiObj = buildResponses(testCodes[3]);
+            responseCode = getSingleSuccessResponse_1["default"](apiObj);
+            expect(responseCode).toBe(undefined);
+            apiObj = buildResponses(asStrings(testCodes[3]));
+            responseCode = getSingleSuccessResponse_1["default"](apiObj);
+            expect(responseCode).toBe(undefined);
+            apiObj = buildResponses(testCodes[4]);
+            responseCode = getSingleSuccessResponse_1["default"](apiObj);
+            expect(responseCode).toBe(undefined);
+            apiObj = buildResponses(asStrings(testCodes[4]));
+            responseCode = getSingleSuccessResponse_1["default"](apiObj);
+            expect(responseCode).toBe(undefined);
+            apiObj = buildResponses(testCodes[5]);
+            responseCode = getSingleSuccessResponse_1["default"](apiObj);
+            expect(responseCode).toBe(undefined);
+            apiObj = buildResponses(asStrings(testCodes[5]));
+            responseCode = getSingleSuccessResponse_1["default"](apiObj);
+            expect(responseCode).toBe(undefined);
+            apiObj = buildResponses(testCodes[6]);
+            responseCode = getSingleSuccessResponse_1["default"](apiObj);
+            expect(responseCode).toBe(undefined);
+            apiObj = buildResponses(asStrings(testCodes[6]));
+            responseCode = getSingleSuccessResponse_1["default"](apiObj);
+            expect(responseCode).toBe(undefined);
+            apiObj = buildResponses(testCodes[7]);
+            responseCode = getSingleSuccessResponse_1["default"](apiObj);
+            expect(responseCode).toBe(undefined);
+            apiObj = buildResponses(asStrings(testCodes[7]));
+            responseCode = getSingleSuccessResponse_1["default"](apiObj);
+            expect(responseCode).toBe(undefined);
+            return [2 /*return*/];
+        });
+    }); });
+    it('returns nothing when there are no 200-level codes', function () { return tslib_1.__awaiter(void 0, void 0, void 0, function () {
+        var testCodes, apiObj, responseCode;
+        return tslib_1.__generator(this, function (_a) {
+            testCodes = [
+                [100, 300, 400, 500],
+                [100, 300, 400, 500],
+                [418, 500],
+                [100, 301, 422, 512],
+                [503, 418, 100],
+                [],
+            ];
+            apiObj = buildResponses(testCodes[0]);
+            responseCode = getSingleSuccessResponse_1["default"](apiObj);
+            expect(responseCode).toBe(undefined);
+            apiObj = buildResponses(asStrings(testCodes[0]));
+            responseCode = getSingleSuccessResponse_1["default"](apiObj);
+            expect(responseCode).toBe(undefined);
+            apiObj = buildResponses(testCodes[1]);
+            responseCode = getSingleSuccessResponse_1["default"](apiObj);
+            expect(responseCode).toBe(undefined);
+            apiObj = buildResponses(asStrings(testCodes[1]));
+            responseCode = getSingleSuccessResponse_1["default"](apiObj);
+            expect(responseCode).toBe(undefined);
+            apiObj = buildResponses(testCodes[2]);
+            responseCode = getSingleSuccessResponse_1["default"](apiObj);
+            expect(responseCode).toBe(undefined);
+            apiObj = buildResponses(asStrings(testCodes[2]));
+            responseCode = getSingleSuccessResponse_1["default"](apiObj);
+            expect(responseCode).toBe(undefined);
+            apiObj = buildResponses(testCodes[3]);
+            responseCode = getSingleSuccessResponse_1["default"](apiObj);
+            expect(responseCode).toBe(undefined);
+            apiObj = buildResponses(asStrings(testCodes[3]));
+            responseCode = getSingleSuccessResponse_1["default"](apiObj);
+            expect(responseCode).toBe(undefined);
+            apiObj = buildResponses(testCodes[4]);
+            responseCode = getSingleSuccessResponse_1["default"](apiObj);
+            expect(responseCode).toBe(undefined);
+            apiObj = buildResponses(asStrings(testCodes[4]));
+            responseCode = getSingleSuccessResponse_1["default"](apiObj);
+            expect(responseCode).toBe(undefined);
+            apiObj = buildResponses(testCodes[5]);
+            responseCode = getSingleSuccessResponse_1["default"](apiObj);
+            expect(responseCode).toBe(undefined);
+            apiObj = buildResponses(asStrings(testCodes[5]));
+            responseCode = getSingleSuccessResponse_1["default"](apiObj);
+            expect(responseCode).toBe(undefined);
+            return [2 /*return*/];
+        });
+    }); });
+});

--- a/build/lib/template/helpers/getSingleSuccessResponse.js
+++ b/build/lib/template/helpers/getSingleSuccessResponse.js
@@ -1,0 +1,10 @@
+"use strict";
+exports.__esModule = true;
+/**
+ * Returns the single 200-level response in responses,
+ * or undefined if not only 1 exists
+ */
+exports["default"] = (function (responses) {
+    var codes = Object.keys(responses).filter(function (code) { return /^2[0-9]+$/.test(code); });
+    return (codes === null || codes === void 0 ? void 0 : codes.length) === 1 ? parseInt(codes[0], 10) : undefined;
+});

--- a/src/lib/template/helpers/__tests__/getSingleSuccessResponse.ts
+++ b/src/lib/template/helpers/__tests__/getSingleSuccessResponse.ts
@@ -1,0 +1,208 @@
+import getSingleSuccessResponse from '@/lib/template/helpers/getSingleSuccessResponse';
+
+const responseObject = {
+  description: 'description',
+  schema: {
+    type: 'object',
+    properties: {
+      id: { type: 'string', description: 'id' },
+      text: { type: 'string', description: 'text' },
+      url: { type: 'string', description: 'url' },
+    },
+  },
+};
+
+const buildResponses = (codes: (number | string)[]): { [key: string]: object; [key: number]: object; } =>
+  (codes || []).reduce((responses, code) =>
+    Object.assign(responses, {
+      [typeof code === 'number' ? code : `${code}`]: responseObject
+    }),
+    {}
+  );
+
+const asStrings = (codes: number[]) => (codes || []).map(String);
+
+describe('getSingleSuccessResponse helper', () => {
+  it('can extract 200-level codes', async () => {
+    const testCodes = [
+      [100, 200, 300, 400, 500],
+      [100, 201, 300, 400, 500],
+      [202, 500],
+      [203],
+      [204],
+      [205, 100],
+      [500, 206],
+    ];
+
+    let apiObj = buildResponses(testCodes[0]);
+    let responseCode = getSingleSuccessResponse(apiObj);
+    expect(responseCode).toBe(200);
+    apiObj = buildResponses(asStrings(testCodes[0]));
+    responseCode = getSingleSuccessResponse(apiObj);
+    expect(responseCode).toBe(200);
+
+    apiObj = buildResponses(testCodes[1]);
+    responseCode = getSingleSuccessResponse(apiObj);
+    expect(responseCode).toBe(201);
+    apiObj = buildResponses(asStrings(testCodes[1]));
+    responseCode = getSingleSuccessResponse(apiObj);
+    expect(responseCode).toBe(201);
+
+    apiObj = buildResponses(testCodes[2]);
+    responseCode = getSingleSuccessResponse(apiObj);
+    expect(responseCode).toBe(202);
+    apiObj = buildResponses(asStrings(testCodes[2]));
+    responseCode = getSingleSuccessResponse(apiObj);
+    expect(responseCode).toBe(202);
+
+    apiObj = buildResponses(testCodes[3]);
+    responseCode = getSingleSuccessResponse(apiObj);
+    expect(responseCode).toBe(203);
+    apiObj = buildResponses(asStrings(testCodes[3]));
+    responseCode = getSingleSuccessResponse(apiObj);
+    expect(responseCode).toBe(203);
+
+    apiObj = buildResponses(testCodes[4]);
+    responseCode = getSingleSuccessResponse(apiObj);
+    expect(responseCode).toBe(204);
+    apiObj = buildResponses(asStrings(testCodes[4]));
+    responseCode = getSingleSuccessResponse(apiObj);
+    expect(responseCode).toBe(204);
+
+    apiObj = buildResponses(testCodes[5]);
+    responseCode = getSingleSuccessResponse(apiObj);
+    expect(responseCode).toBe(205);
+    apiObj = buildResponses(asStrings(testCodes[5]));
+    responseCode = getSingleSuccessResponse(apiObj);
+    expect(responseCode).toBe(205);
+
+    apiObj = buildResponses(testCodes[6]);
+    responseCode = getSingleSuccessResponse(apiObj);
+    expect(responseCode).toBe(206);
+    apiObj = buildResponses(asStrings(testCodes[6]));
+    responseCode = getSingleSuccessResponse(apiObj);
+    expect(responseCode).toBe(206);
+  });
+
+  it('returns nothing when there are multiple 200-level codes', async () => {
+    const testCodes = [
+      [100, 200, 201, 300, 400, 500],
+      [100, 201, 202, 300, 400, 500],
+      [202, 203, 500],
+      [203, 204],
+      [204, 205],
+      [205, 204],
+      [206, 205, 100],
+      [500, 418, 200, 206],
+    ];
+
+    let apiObj = buildResponses(testCodes[0]);
+    let responseCode = getSingleSuccessResponse(apiObj);
+    expect(responseCode).toBe(undefined);
+    apiObj = buildResponses(asStrings(testCodes[0]));
+    responseCode = getSingleSuccessResponse(apiObj);
+    expect(responseCode).toBe(undefined);
+
+    apiObj = buildResponses(testCodes[1]);
+    responseCode = getSingleSuccessResponse(apiObj);
+    expect(responseCode).toBe(undefined);
+    apiObj = buildResponses(asStrings(testCodes[1]));
+    responseCode = getSingleSuccessResponse(apiObj);
+    expect(responseCode).toBe(undefined);
+
+    apiObj = buildResponses(testCodes[2]);
+    responseCode = getSingleSuccessResponse(apiObj);
+    expect(responseCode).toBe(undefined);
+    apiObj = buildResponses(asStrings(testCodes[2]));
+    responseCode = getSingleSuccessResponse(apiObj);
+    expect(responseCode).toBe(undefined);
+
+    apiObj = buildResponses(testCodes[3]);
+    responseCode = getSingleSuccessResponse(apiObj);
+    expect(responseCode).toBe(undefined);
+    apiObj = buildResponses(asStrings(testCodes[3]));
+    responseCode = getSingleSuccessResponse(apiObj);
+    expect(responseCode).toBe(undefined);
+
+    apiObj = buildResponses(testCodes[4]);
+    responseCode = getSingleSuccessResponse(apiObj);
+    expect(responseCode).toBe(undefined);
+    apiObj = buildResponses(asStrings(testCodes[4]));
+    responseCode = getSingleSuccessResponse(apiObj);
+    expect(responseCode).toBe(undefined);
+
+    apiObj = buildResponses(testCodes[5]);
+    responseCode = getSingleSuccessResponse(apiObj);
+    expect(responseCode).toBe(undefined);
+    apiObj = buildResponses(asStrings(testCodes[5]));
+    responseCode = getSingleSuccessResponse(apiObj);
+    expect(responseCode).toBe(undefined);
+
+    apiObj = buildResponses(testCodes[6]);
+    responseCode = getSingleSuccessResponse(apiObj);
+    expect(responseCode).toBe(undefined);
+    apiObj = buildResponses(asStrings(testCodes[6]));
+    responseCode = getSingleSuccessResponse(apiObj);
+    expect(responseCode).toBe(undefined);
+
+    apiObj = buildResponses(testCodes[7]);
+    responseCode = getSingleSuccessResponse(apiObj);
+    expect(responseCode).toBe(undefined);
+    apiObj = buildResponses(asStrings(testCodes[7]));
+    responseCode = getSingleSuccessResponse(apiObj);
+    expect(responseCode).toBe(undefined);
+  });
+
+  it('returns nothing when there are no 200-level codes', async () => {
+    const testCodes = [
+      [100, 300, 400, 500],
+      [100, 300, 400, 500],
+      [418, 500],
+      [100, 301, 422, 512],
+      [503, 418, 100],
+      [],
+    ];
+
+    let apiObj = buildResponses(testCodes[0]);
+    let responseCode = getSingleSuccessResponse(apiObj);
+    expect(responseCode).toBe(undefined);
+    apiObj = buildResponses(asStrings(testCodes[0]));
+    responseCode = getSingleSuccessResponse(apiObj);
+    expect(responseCode).toBe(undefined);
+
+    apiObj = buildResponses(testCodes[1]);
+    responseCode = getSingleSuccessResponse(apiObj);
+    expect(responseCode).toBe(undefined);
+    apiObj = buildResponses(asStrings(testCodes[1]));
+    responseCode = getSingleSuccessResponse(apiObj);
+    expect(responseCode).toBe(undefined);
+
+    apiObj = buildResponses(testCodes[2]);
+    responseCode = getSingleSuccessResponse(apiObj);
+    expect(responseCode).toBe(undefined);
+    apiObj = buildResponses(asStrings(testCodes[2]));
+    responseCode = getSingleSuccessResponse(apiObj);
+    expect(responseCode).toBe(undefined);
+
+    apiObj = buildResponses(testCodes[3]);
+    responseCode = getSingleSuccessResponse(apiObj);
+    expect(responseCode).toBe(undefined);
+    apiObj = buildResponses(asStrings(testCodes[3]));
+    responseCode = getSingleSuccessResponse(apiObj);
+    expect(responseCode).toBe(undefined);
+
+    apiObj = buildResponses(testCodes[4]);
+    responseCode = getSingleSuccessResponse(apiObj);
+    expect(responseCode).toBe(undefined);
+    apiObj = buildResponses(asStrings(testCodes[4]));
+    responseCode = getSingleSuccessResponse(apiObj);
+    expect(responseCode).toBe(undefined);
+
+    apiObj = buildResponses(testCodes[5]);
+    responseCode = getSingleSuccessResponse(apiObj);
+    expect(responseCode).toBe(undefined);
+    apiObj = buildResponses(asStrings(testCodes[5]));
+    responseCode = getSingleSuccessResponse(apiObj);
+    expect(responseCode).toBe(undefined);
+  });
+});

--- a/src/lib/template/helpers/getSingleSuccessResponse.ts
+++ b/src/lib/template/helpers/getSingleSuccessResponse.ts
@@ -1,0 +1,9 @@
+/**
+ * Returns the single 200-level response in responses,
+ * or undefined if not only 1 exists
+ */
+export default (responses: { [key: string]: any; [key: number]: any; }): number => {
+  const codes = Object.keys(responses).filter(code => /^2[0-9]+$/.test(code));
+
+  return codes?.length === 1 ? parseInt(codes[0], 10) : undefined;
+};


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
By default, the http routes will always generate 200's for success. This means the swagger definitions will disagree with the implementation

**Describe the solution you'd like**
If there is a single success (200-level) response defined in the yml for a route, then it would be cool it the generated files automatically extracted that

**Describe alternatives you've considered**
Manually changing the routes, which results in being overridden on re-generate

**Additional context**
will add `.status(<code>)` if there is only 1 200-level status code in path responses

used by https://github.com/acrontum/openapi-nodegen-typescript-server/pull/8