### PR TITLE
fix: joi now accepts spread instead of array

### DIFF
--- a/src/lib/helpers/SwaggerUtils.ts
+++ b/src/lib/helpers/SwaggerUtils.ts
@@ -34,7 +34,7 @@ class SwaggerUtils {
       }
       if (param.enum || (param.schema && param.schema.enum)) {
         const enumValues = param.enum || param.schema.enum;
-        validationText += '.valid([' + enumValues.map((e: string) => `'${e}'`).join(', ') + '])';
+        validationText += '.valid(' + enumValues.map((e: string) => `'${e}'`).join(', ') + ')';
       }
 
       if (param.minLength) {


### PR DESCRIPTION
Enum in swagger causes validations to fail:

```yaml
enumThing:
  type: string
  enum: [one, two]
```
joi / hapi / hoek throws:
`Error: Method no longer accepts array arguments: valid`

```typescript
{
  ...
  enumThing: Joi.string().allow('').valid(['one', 'two']),
```
celebrate@12.1.0