### PR TITLE
do not allow empty string if min length required

### DIFF
--- a/src/lib/helpers/SwaggerUtils.ts
+++ b/src/lib/helpers/SwaggerUtils.ts
@@ -22,7 +22,7 @@ class SwaggerUtils {
         validationText += 'Joi.' + type + '()';
       }
 
-      if (type === 'string' && !isRequired) {
+      if (type === 'string' && !isRequired && !param.minLength) {
         validationText += `.allow('')`;
       }
       if (param.default) {


### PR DESCRIPTION
fix conflicting validations when a string is optional, but also has a minimum length