### PR TITLE
Feature/child packagejson not present

### DIFF
--- a/build/lib/diff/displayDependencyDiffs.js
+++ b/build/lib/diff/displayDependencyDiffs.js
@@ -6,9 +6,13 @@ var fs_extra_1 = tslib_1.__importDefault(require("fs-extra"));
 var path_1 = tslib_1.__importDefault(require("path"));
 var suggestVersionUpgrade_1 = require("../helpers/suggestVersionUpgrade");
 exports["default"] = (function (targetDir, templatesDir) {
-    var packagJsonStr = 'package.json';
-    var existing = JSON.parse(fs_extra_1["default"].readFileSync(path_1["default"].join(targetDir, packagJsonStr), { encoding: 'utf8' }));
-    var newJson = JSON.parse(fs_extra_1["default"].readFileSync(path_1["default"].join(templatesDir, packagJsonStr + '.njk'), 'utf8'));
+    var packageJsonStr = 'package.json';
+    var targetPackageJson = path_1["default"].join(targetDir, packageJsonStr);
+    if (!fs_extra_1["default"].pathExistsSync(targetPackageJson)) {
+        return;
+    }
+    var existing = JSON.parse(fs_extra_1["default"].readFileSync(targetPackageJson, { encoding: 'utf8' }));
+    var newJson = JSON.parse(fs_extra_1["default"].readFileSync(path_1["default"].join(templatesDir, packageJsonStr + '.njk'), 'utf8'));
     var scriptsChanged = {};
     var dependenciesChanged = {};
     var devDependenciesChanged = {};

--- a/src/lib/diff/displayDependencyDiffs.ts
+++ b/src/lib/diff/displayDependencyDiffs.ts
@@ -3,17 +3,22 @@ import fs from 'fs-extra';
 import path from 'path';
 import { suggestVersionUpgrade } from '../helpers/suggestVersionUpgrade';
 
-export default (targetDir: string, templatesDir: string) => {
-  const packagJsonStr = 'package.json';
+export default (targetDir: string, templatesDir: string): void => {
+  const packageJsonStr = 'package.json';
+  const targetPackageJson = path.join(targetDir, packageJsonStr);
+  if (!fs.pathExistsSync(targetPackageJson)) {
+    return;
+  }
+
   const existing = JSON.parse(
     fs.readFileSync(
-      path.join(targetDir, packagJsonStr),
+      targetPackageJson,
       {encoding: 'utf8'},
     ),
   );
   const newJson = JSON.parse(
     fs.readFileSync(
-      path.join(templatesDir, packagJsonStr + '.njk'),
+      path.join(templatesDir, packageJsonStr + '.njk'),
       'utf8',
     ),
   );


### PR DESCRIPTION
When using generate-it inside an existing repo there is usually not a package.json, before this fix, the package diff tool throws an error when the targetDir doesn't contain a package.json file. Now it gracefully moves on. 