### PR TITLE
feat: segmentSecondGrouping for versioned apis and grouping monolitic beastly api's

### DIFF
--- a/build/cli.js
+++ b/build/cli.js
@@ -24,6 +24,7 @@ npm_tool_version_check_1["default"](require('../package.json').version, 'https:/
         template: cli.program.template,
         variables: cli.program.variables,
         segmentFirstGrouping: cli.program.segmentFirstGrouping,
+        segmentSecondGrouping: cli.program.segmentSecondGrouping,
         handlebars_helper: undefined,
         mockServer: cli.program.mocked || false
     };

--- a/build/commander.js
+++ b/build/commander.js
@@ -21,6 +21,7 @@ exports["default"] = (function (inputArgsArray) {
         .option('--dont-update-tpl-cache', 'If the given git url is already cached does not attempt to update', false)
         .option('--dont-run-comparison-tool', 'Skips the stub file comparison tool and version cleanup', false)
         .option('--segment-first-grouping <number>', 'If set will split a domain by group the 1 qty of segments defined in this setting, see endpointNameCalculation.ts')
+        .option('--segment-second-grouping <number>', 'Assuming the 1st grouping is set, this will group the 2nd group into another 2 groups, see endpointNameCalculation.ts')
         .option('-$, --variables [value]', 'Array of variables to pass to the templates, eg "-$ httpLibImportStr=@/services/HttpService -$ apikey=321654987"', commanderCollectObject_1["default"], {})
         .option('-v, --verbose', 'Outputs verbose logging')
         .option('--very-verbose', 'Outputs very verbose logging')

--- a/build/lib/FileIterator.js
+++ b/build/lib/FileIterator.js
@@ -95,6 +95,7 @@ var FileWalker = /** @class */ (function () {
             data: this.config,
             file_name: filename,
             segmentFirstGrouping: this.config.segmentFirstGrouping,
+            segmentSecondGrouping: this.config.segmentSecondGrouping,
             mockServer: this.config.mockServer
         };
     };

--- a/build/lib/helpers/__tests__/endpointNameCalculation.js
+++ b/build/lib/helpers/__tests__/endpointNameCalculation.js
@@ -125,6 +125,30 @@ describe('1st grouping only', function () {
     }); });
 });
 describe('1st and 2nd grouping', function () {
+    it('should throw error when 1st is >= to 2nd', function (done) { return tslib_1.__awaiter(void 0, void 0, void 0, function () {
+        return tslib_1.__generator(this, function (_a) {
+            try {
+                endpointNameCalculation_1["default"]('/item/{id}/comment/thing', {
+                    segmentFirstGrouping: 2,
+                    segmentSecondGrouping: 2
+                });
+                done('The 1st is equal to the 2nd');
+            }
+            catch (e) {
+                try {
+                    endpointNameCalculation_1["default"]('/item/{id}/comment/thing', {
+                        segmentFirstGrouping: 3,
+                        segmentSecondGrouping: 2
+                    });
+                    done('The 1st is greater than the 2nd');
+                }
+                catch (e) {
+                    done();
+                }
+            }
+            return [2 /*return*/];
+        });
+    }); });
     it('should return itemComment as the 1st grouping is 0 the same as the base segment', function () { return tslib_1.__awaiter(void 0, void 0, void 0, function () {
         var endpoint;
         return tslib_1.__generator(this, function (_a) {

--- a/build/lib/helpers/__tests__/endpointNameCalculation.js
+++ b/build/lib/helpers/__tests__/endpointNameCalculation.js
@@ -2,61 +2,198 @@
 exports.__esModule = true;
 var tslib_1 = require("tslib");
 var endpointNameCalculation_1 = tslib_1.__importDefault(require("../endpointNameCalculation"));
-it('should return the 1st segment only for no count passed', function () { return tslib_1.__awaiter(void 0, void 0, void 0, function () {
-    var endpoint;
-    return tslib_1.__generator(this, function (_a) {
-        endpoint = endpointNameCalculation_1["default"]('/item/{id}', {});
-        expect(endpoint).toBe('item');
-        return [2 /*return*/];
-    });
-}); });
-it('should return the 1st segment only when the count 2  & only 2 path segments', function () { return tslib_1.__awaiter(void 0, void 0, void 0, function () {
-    var endpoint;
-    return tslib_1.__generator(this, function (_a) {
-        endpoint = endpointNameCalculation_1["default"]('/item/{id}', {
-            segmentFirstGrouping: 2
+describe('no grouping', function () {
+    it('should return root for /', function () { return tslib_1.__awaiter(void 0, void 0, void 0, function () {
+        var endpoint;
+        return tslib_1.__generator(this, function (_a) {
+            endpoint = endpointNameCalculation_1["default"]('/', {});
+            expect(endpoint).toBe('root');
+            return [2 /*return*/];
         });
-        expect(endpoint).toBe('item');
-        return [2 /*return*/];
-    });
-}); });
-it('should return the 1st segment only', function () { return tslib_1.__awaiter(void 0, void 0, void 0, function () {
-    var endpoint;
-    return tslib_1.__generator(this, function (_a) {
-        endpoint = endpointNameCalculation_1["default"]('/item/{id}/comment', {
-            segmentFirstGrouping: 2
+    }); });
+    it('should fix path without leading /', function () { return tslib_1.__awaiter(void 0, void 0, void 0, function () {
+        var endpoint;
+        return tslib_1.__generator(this, function (_a) {
+            endpoint = endpointNameCalculation_1["default"]('item', {});
+            expect(endpoint).toBe('item');
+            return [2 /*return*/];
         });
-        expect(endpoint).toBe('itemComment');
-        return [2 /*return*/];
-    });
-}); });
-it('should return itemComment', function () { return tslib_1.__awaiter(void 0, void 0, void 0, function () {
-    var endpoint;
-    return tslib_1.__generator(this, function (_a) {
-        endpoint = endpointNameCalculation_1["default"]('/item/{id}/comment/thing', {
-            segmentFirstGrouping: 2
+    }); });
+    it('should return the 1st segment only for no count passed', function () { return tslib_1.__awaiter(void 0, void 0, void 0, function () {
+        var endpoint;
+        return tslib_1.__generator(this, function (_a) {
+            endpoint = endpointNameCalculation_1["default"]('/item', {});
+            expect(endpoint).toBe('item');
+            return [2 /*return*/];
         });
-        expect(endpoint).toBe('itemComment');
-        return [2 /*return*/];
-    });
-}); });
-it('should return itemThing', function () { return tslib_1.__awaiter(void 0, void 0, void 0, function () {
-    var endpoint;
-    return tslib_1.__generator(this, function (_a) {
-        endpoint = endpointNameCalculation_1["default"]('/item/{id}/comment/thing', {
-            segmentFirstGrouping: 3
+    }); });
+    it('should return the 1st segment only for no count passed', function () { return tslib_1.__awaiter(void 0, void 0, void 0, function () {
+        var endpoint;
+        return tslib_1.__generator(this, function (_a) {
+            endpoint = endpointNameCalculation_1["default"]('/item/', {});
+            expect(endpoint).toBe('item');
+            return [2 /*return*/];
         });
-        expect(endpoint).toBe('itemThing');
-        return [2 /*return*/];
-    });
-}); });
-it('should return itemId', function () { return tslib_1.__awaiter(void 0, void 0, void 0, function () {
-    var endpoint;
-    return tslib_1.__generator(this, function (_a) {
-        endpoint = endpointNameCalculation_1["default"]('/item/{id}/comment/thing', {
-            segmentFirstGrouping: 1
+    }); });
+    it('should return the 1st segment only for no count passed', function () { return tslib_1.__awaiter(void 0, void 0, void 0, function () {
+        var endpoint;
+        return tslib_1.__generator(this, function (_a) {
+            endpoint = endpointNameCalculation_1["default"]('/item/{id}', {});
+            expect(endpoint).toBe('item');
+            return [2 /*return*/];
         });
-        expect(endpoint).toBe('itemId');
-        return [2 /*return*/];
-    });
-}); });
+    }); });
+    it('should return the 1st segment only for no count passed', function () { return tslib_1.__awaiter(void 0, void 0, void 0, function () {
+        var endpoint;
+        return tslib_1.__generator(this, function (_a) {
+            endpoint = endpointNameCalculation_1["default"]('/item/{id}/comment', {});
+            expect(endpoint).toBe('item');
+            return [2 /*return*/];
+        });
+    }); });
+});
+describe('1st grouping only', function () {
+    it('should return the 1st segment only as 1st grouping is 0', function () { return tslib_1.__awaiter(void 0, void 0, void 0, function () {
+        var endpoint;
+        return tslib_1.__generator(this, function (_a) {
+            endpoint = endpointNameCalculation_1["default"]('/item/{id}', {
+                segmentFirstGrouping: 0
+            });
+            expect(endpoint).toBe('item');
+            return [2 /*return*/];
+        });
+    }); });
+    it('should return the 1st & 2nd segment', function () { return tslib_1.__awaiter(void 0, void 0, void 0, function () {
+        var endpoint;
+        return tslib_1.__generator(this, function (_a) {
+            endpoint = endpointNameCalculation_1["default"]('/item/{id}', {
+                segmentFirstGrouping: 1
+            });
+            expect(endpoint).toBe('itemId');
+            return [2 /*return*/];
+        });
+    }); });
+    it('should return the 1st segment only when the count 2  & only 2 path segments', function () { return tslib_1.__awaiter(void 0, void 0, void 0, function () {
+        var endpoint;
+        return tslib_1.__generator(this, function (_a) {
+            endpoint = endpointNameCalculation_1["default"]('/item/{id}', {
+                segmentFirstGrouping: 2
+            });
+            expect(endpoint).toBe('item');
+            return [2 /*return*/];
+        });
+    }); });
+    it('should return the 1st segment only', function () { return tslib_1.__awaiter(void 0, void 0, void 0, function () {
+        var endpoint;
+        return tslib_1.__generator(this, function (_a) {
+            endpoint = endpointNameCalculation_1["default"]('/item/{id}/comment', {
+                segmentFirstGrouping: 2
+            });
+            expect(endpoint).toBe('itemComment');
+            return [2 /*return*/];
+        });
+    }); });
+    it('should return itemComment and not the remaining segments', function () { return tslib_1.__awaiter(void 0, void 0, void 0, function () {
+        var endpoint;
+        return tslib_1.__generator(this, function (_a) {
+            endpoint = endpointNameCalculation_1["default"]('/item/{id}/comment/thing', {
+                segmentFirstGrouping: 2
+            });
+            expect(endpoint).toBe('itemComment');
+            return [2 /*return*/];
+        });
+    }); });
+    it('should return itemThing', function () { return tslib_1.__awaiter(void 0, void 0, void 0, function () {
+        var endpoint;
+        return tslib_1.__generator(this, function (_a) {
+            endpoint = endpointNameCalculation_1["default"]('/item/{id}/comment/thing', {
+                segmentFirstGrouping: 3
+            });
+            expect(endpoint).toBe('itemThing');
+            return [2 /*return*/];
+        });
+    }); });
+    it('should return itemId', function () { return tslib_1.__awaiter(void 0, void 0, void 0, function () {
+        var endpoint;
+        return tslib_1.__generator(this, function (_a) {
+            endpoint = endpointNameCalculation_1["default"]('/item/{id}/comment/thing', {
+                segmentFirstGrouping: 1
+            });
+            expect(endpoint).toBe('itemId');
+            return [2 /*return*/];
+        });
+    }); });
+});
+describe('1st and 2nd grouping', function () {
+    it('should return itemComment as the 1st grouping is 0 the same as the base segment', function () { return tslib_1.__awaiter(void 0, void 0, void 0, function () {
+        var endpoint;
+        return tslib_1.__generator(this, function (_a) {
+            endpoint = endpointNameCalculation_1["default"]('/item/{id}/comment/thing', {
+                segmentFirstGrouping: 0,
+                segmentSecondGrouping: 2
+            });
+            expect(endpoint).toBe('itemComment');
+            return [2 /*return*/];
+        });
+    }); });
+    it('should return itemIdComment', function () { return tslib_1.__awaiter(void 0, void 0, void 0, function () {
+        var endpoint;
+        return tslib_1.__generator(this, function (_a) {
+            endpoint = endpointNameCalculation_1["default"]('/item/{id}/comment/thing', {
+                segmentFirstGrouping: 1,
+                segmentSecondGrouping: 2
+            });
+            expect(endpoint).toBe('itemIdComment');
+            return [2 /*return*/];
+        });
+    }); });
+    it('should return itemId', function () { return tslib_1.__awaiter(void 0, void 0, void 0, function () {
+        var endpoint;
+        return tslib_1.__generator(this, function (_a) {
+            endpoint = endpointNameCalculation_1["default"]('/item/{id}/comment', {
+                segmentFirstGrouping: 1,
+                segmentSecondGrouping: 3
+            });
+            expect(endpoint).toBe('itemId');
+            return [2 /*return*/];
+        });
+    }); });
+    it('should return itemIdThing', function () { return tslib_1.__awaiter(void 0, void 0, void 0, function () {
+        var endpoint;
+        return tslib_1.__generator(this, function (_a) {
+            endpoint = endpointNameCalculation_1["default"]('/item/{id}/comment/thing', {
+                segmentFirstGrouping: 1,
+                segmentSecondGrouping: 3
+            });
+            expect(endpoint).toBe('itemIdThing');
+            return [2 /*return*/];
+        });
+    }); });
+    it('should return itemIdThing', function () { return tslib_1.__awaiter(void 0, void 0, void 0, function () {
+        var endpoint;
+        return tslib_1.__generator(this, function (_a) {
+            endpoint = endpointNameCalculation_1["default"]('/item/{id}/comment/thing', {
+                segmentFirstGrouping: 2,
+                segmentSecondGrouping: 3
+            });
+            expect(endpoint).toBe('itemCommentThing');
+            return [2 /*return*/];
+        });
+    }); });
+});
+describe('2nd grouping only', function () {
+    it('should throw an error', function (done) { return tslib_1.__awaiter(void 0, void 0, void 0, function () {
+        return tslib_1.__generator(this, function (_a) {
+            try {
+                endpointNameCalculation_1["default"]('/item/{id}/comment/thing', {
+                    segmentSecondGrouping: 2
+                });
+                done('Should have thrown an error when only passing segmentSecondGrouping with no segmentFirstGrouping');
+            }
+            catch (e) {
+                done();
+            }
+            return [2 /*return*/];
+        });
+    }); });
+});

--- a/build/lib/helpers/endpointNameCalculation.js
+++ b/build/lib/helpers/endpointNameCalculation.js
@@ -3,6 +3,10 @@ exports.__esModule = true;
 var tslib_1 = require("tslib");
 var ucFirst_1 = tslib_1.__importDefault(require("../template/helpers/ucFirst"));
 exports["default"] = (function (fullPath, config) {
+    var segmentFirstGrouping = config.segmentFirstGrouping, segmentSecondGrouping = config.segmentSecondGrouping;
+    if (segmentFirstGrouping === undefined && segmentSecondGrouping !== undefined) {
+        throw new Error('You must provide segmentFirstGrouping when providing segmentSecondGrouping. segmentSecondGrouping found but segmentFirstGrouping is undefined');
+    }
     // double check the 1st char is /
     if (fullPath[0] !== '/') {
         fullPath = '/' + fullPath;
@@ -10,16 +14,24 @@ exports["default"] = (function (fullPath, config) {
     if (fullPath === '/') {
         return 'root';
     }
-    if (!config.segmentFirstGrouping) {
+    if (segmentFirstGrouping === undefined || segmentFirstGrouping === 0 && !segmentSecondGrouping) {
         return fullPath.split('/')[1];
     }
-    var segmentFirstGrouping = config.segmentFirstGrouping;
     var segments = fullPath.split('/');
     // Get rid of the empty slot
     segments.shift();
     if (segmentFirstGrouping >= segments.length) {
         return fullPath.split('/')[1];
     }
+    if (!segmentSecondGrouping || segmentSecondGrouping && segmentSecondGrouping >= segments.length) {
+        return segments[0].replace(/{*}*/gm, '')
+            + ucFirst_1["default"](segments[segmentFirstGrouping].replace(/{*}*/gm, ''));
+    }
+    if (segmentFirstGrouping === 0) {
+        return segments[0].replace(/{*}*/gm, '')
+            + ucFirst_1["default"](segments[segmentSecondGrouping].replace(/{*}*/gm, ''));
+    }
     return segments[0].replace(/{*}*/gm, '')
-        + ucFirst_1["default"](segments[segmentFirstGrouping].replace(/{*}*/gm, ''));
+        + ucFirst_1["default"](segments[segmentFirstGrouping].replace(/{*}*/gm, ''))
+        + ucFirst_1["default"](segments[segmentSecondGrouping].replace(/{*}*/gm, ''));
 });

--- a/build/lib/helpers/endpointNameCalculation.js
+++ b/build/lib/helpers/endpointNameCalculation.js
@@ -7,6 +7,11 @@ exports["default"] = (function (fullPath, config) {
     if (segmentFirstGrouping === undefined && segmentSecondGrouping !== undefined) {
         throw new Error('You must provide segmentFirstGrouping when providing segmentSecondGrouping. segmentSecondGrouping found but segmentFirstGrouping is undefined');
     }
+    if (segmentFirstGrouping !== undefined && segmentSecondGrouping !== undefined) {
+        if (segmentFirstGrouping >= segmentSecondGrouping) {
+            throw new Error('When setting the segmentSecondGrouping it must be greater that the segmentFirstGrouping');
+        }
+    }
     // double check the 1st char is /
     if (fullPath[0] !== '/') {
         fullPath = '/' + fullPath;

--- a/build/lib/openapi/OpenAPIBundler.js
+++ b/build/lib/openapi/OpenAPIBundler.js
@@ -317,7 +317,8 @@ var OpenAPIBundler = /** @class */ (function () {
         var objects = apiObject.channels || apiObject.paths;
         for (var fullPath in objects) {
             var endpointName = endpointNameCalculation_1["default"](fullPath, {
-                segmentFirstGrouping: config.segmentFirstGrouping || config.nodegenRc.segmentFirstGrouping
+                segmentFirstGrouping: config.segmentFirstGrouping || config.nodegenRc.segmentFirstGrouping,
+                segmentSecondGrouping: config.segmentSecondGrouping || config.nodegenRc.segmentSecondGrouping
             });
             var pathObject = objects[fullPath];
             if (includeOperationNameAction_1["default"](endpointName, pathObject, config.nodegenRc)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generate-it",
-  "version": "5.14.0",
+  "version": "5.15.0",
   "description": "Generate it, socket and html consumers and clients from yml files (openapi/asyncapi)",
   "author": "Acrontum GmbH",
   "license": "MIT",
@@ -21,6 +21,7 @@
     "start": "node cli.js",
     "prepublishOnly": "npm run test"
   },
+  "homepage": "https://acrontum.github.io/generate-it",
   "repository": {
     "type": "git",
     "url": "https://github.com/acrontum/generate-it"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,6 +28,7 @@ versionCheck(
     template: cli.program.template,
     variables: cli.program.variables,
     segmentFirstGrouping: cli.program.segmentFirstGrouping,
+    segmentSecondGrouping: cli.program.segmentSecondGrouping,
     handlebars_helper: undefined, // todo add the ability to inject custom helpers, this will allow the extraction of Joi form the core
     mockServer: cli.program.mocked || false,
   };

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -20,6 +20,7 @@ export default (inputArgsArray: string[]) => {
     .option('--dont-update-tpl-cache', 'If the given git url is already cached does not attempt to update', false)
     .option('--dont-run-comparison-tool', 'Skips the stub file comparison tool and version cleanup', false)
     .option('--segment-first-grouping <number>', 'If set will split a domain by group the 1 qty of segments defined in this setting, see endpointNameCalculation.ts')
+    .option('--segment-second-grouping <number>', 'Assuming the 1st grouping is set, this will group the 2nd group into another 2 groups, see endpointNameCalculation.ts')
     .option('-$, --variables [value]', 'Array of variables to pass to the templates, eg "-$ httpLibImportStr=@/services/HttpService -$ apikey=321654987"', commanderCollectArray, {})
     .option('-v, --verbose', 'Outputs verbose logging')
     .option('--very-verbose', 'Outputs very verbose logging')

--- a/src/interfaces/Config.ts
+++ b/src/interfaces/Config.ts
@@ -7,6 +7,7 @@ export default interface Config {
   dontUpdateTplCache: boolean;
   dontRunComparisonTool: boolean;
   segmentFirstGrouping?: number;
+  segmentSecondGrouping?: number;
   handlebars_helper?: any;
   mockServer: boolean;
   variables?: any;

--- a/src/interfaces/GenerateOperationFileConfig.ts
+++ b/src/interfaces/GenerateOperationFileConfig.ts
@@ -8,6 +8,7 @@ export default interface GenerateOperationFileConfig {
   package: Package;
   data: ConfigExtendedBase;
   file_name: string;
-  segmentFirstGrouping: number;
+  segmentFirstGrouping?: number;
+  segmentSecondGrouping?: number;
   mockServer: boolean;
 }

--- a/src/interfaces/NodegenRc.ts
+++ b/src/interfaces/NodegenRc.ts
@@ -4,6 +4,7 @@ export default interface NodegenRc {
   nodegenType: string;
   interfaceStyle?: string;
   segmentFirstGrouping?: number;
+  segmentSecondGrouping?: number;
   helpers?: {
     publishOpIds?: string[],
     subscribeOpIds?: string[],

--- a/src/lib/FileIterator.ts
+++ b/src/lib/FileIterator.ts
@@ -86,6 +86,7 @@ class FileWalker {
       data: this.config,
       file_name: filename,
       segmentFirstGrouping: this.config.segmentFirstGrouping,
+      segmentSecondGrouping: this.config.segmentSecondGrouping,
       mockServer: this.config.mockServer,
     };
   }

--- a/src/lib/helpers/__tests__/endpointNameCalculation.ts
+++ b/src/lib/helpers/__tests__/endpointNameCalculation.ts
@@ -79,6 +79,25 @@ describe('1st grouping only', () => {
 });
 
 describe('1st and 2nd grouping', () => {
+  it('should throw error when 1st is >= to 2nd', async (done) => {
+    try {
+      endpointNameCalculation('/item/{id}/comment/thing', {
+        segmentFirstGrouping: 2,
+        segmentSecondGrouping: 2
+      });
+      done('The 1st is equal to the 2nd');
+    } catch (e) {
+      try {
+        endpointNameCalculation('/item/{id}/comment/thing', {
+          segmentFirstGrouping: 3,
+          segmentSecondGrouping: 2
+        });
+        done('The 1st is greater than the 2nd');
+      } catch (e) {
+        done();
+      }
+    }
+  });
   it('should return itemComment as the 1st grouping is 0 the same as the base segment', async () => {
     const endpoint = endpointNameCalculation('/item/{id}/comment/thing', {
       segmentFirstGrouping: 0,

--- a/src/lib/helpers/__tests__/endpointNameCalculation.ts
+++ b/src/lib/helpers/__tests__/endpointNameCalculation.ts
@@ -1,41 +1,134 @@
 import endpointNameCalculation from '@/lib/helpers/endpointNameCalculation';
 
-it('should return the 1st segment only for no count passed', async () => {
-  const endpoint = endpointNameCalculation('/item/{id}', {});
-  expect(endpoint).toBe('item');
+describe('no grouping', () => {
+  it('should return root for /', async () => {
+    const endpoint = endpointNameCalculation('/', {});
+    expect(endpoint).toBe('root');
+  });
+  it('should fix path without leading /', async () => {
+    const endpoint = endpointNameCalculation('item', {});
+    expect(endpoint).toBe('item');
+  });
+  it('should return the 1st segment only for no count passed', async () => {
+    const endpoint = endpointNameCalculation('/item', {});
+    expect(endpoint).toBe('item');
+  });
+  it('should return the 1st segment only for no count passed', async () => {
+    const endpoint = endpointNameCalculation('/item/', {});
+    expect(endpoint).toBe('item');
+  });
+  it('should return the 1st segment only for no count passed', async () => {
+    const endpoint = endpointNameCalculation('/item/{id}', {});
+    expect(endpoint).toBe('item');
+  });
+  it('should return the 1st segment only for no count passed', async () => {
+    const endpoint = endpointNameCalculation('/item/{id}/comment', {});
+    expect(endpoint).toBe('item');
+  });
 });
 
-it('should return the 1st segment only when the count 2  & only 2 path segments', async () => {
-  const endpoint = endpointNameCalculation('/item/{id}', {
-    segmentFirstGrouping: 2
+describe('1st grouping only', () => {
+  it('should return the 1st segment only as 1st grouping is 0', async () => {
+    const endpoint = endpointNameCalculation('/item/{id}', {
+      segmentFirstGrouping: 0
+    });
+    expect(endpoint).toBe('item');
   });
-  expect(endpoint).toBe('item');
+
+  it('should return the 1st & 2nd segment', async () => {
+    const endpoint = endpointNameCalculation('/item/{id}', {
+      segmentFirstGrouping: 1
+    });
+    expect(endpoint).toBe('itemId');
+  });
+
+  it('should return the 1st segment only when the count 2  & only 2 path segments', async () => {
+    const endpoint = endpointNameCalculation('/item/{id}', {
+      segmentFirstGrouping: 2
+    });
+    expect(endpoint).toBe('item');
+  });
+
+  it('should return the 1st segment only', async () => {
+    const endpoint = endpointNameCalculation('/item/{id}/comment', {
+      segmentFirstGrouping: 2
+    });
+    expect(endpoint).toBe('itemComment');
+  });
+
+  it('should return itemComment and not the remaining segments', async () => {
+    const endpoint = endpointNameCalculation('/item/{id}/comment/thing', {
+      segmentFirstGrouping: 2
+    });
+    expect(endpoint).toBe('itemComment');
+  });
+
+  it('should return itemThing', async () => {
+    const endpoint = endpointNameCalculation('/item/{id}/comment/thing', {
+      segmentFirstGrouping: 3
+    });
+    expect(endpoint).toBe('itemThing');
+  });
+
+  it('should return itemId', async () => {
+    const endpoint = endpointNameCalculation('/item/{id}/comment/thing', {
+      segmentFirstGrouping: 1
+    });
+    expect(endpoint).toBe('itemId');
+  });
 });
 
-it('should return the 1st segment only', async () => {
-  const endpoint = endpointNameCalculation('/item/{id}/comment', {
-    segmentFirstGrouping: 2
+describe('1st and 2nd grouping', () => {
+  it('should return itemComment as the 1st grouping is 0 the same as the base segment', async () => {
+    const endpoint = endpointNameCalculation('/item/{id}/comment/thing', {
+      segmentFirstGrouping: 0,
+      segmentSecondGrouping: 2
+    });
+    expect(endpoint).toBe('itemComment');
   });
-  expect(endpoint).toBe('itemComment');
+
+  it('should return itemIdComment', async () => {
+    const endpoint = endpointNameCalculation('/item/{id}/comment/thing', {
+      segmentFirstGrouping: 1,
+      segmentSecondGrouping: 2
+    });
+    expect(endpoint).toBe('itemIdComment');
+  });
+
+  it('should return itemId', async () => {
+    const endpoint = endpointNameCalculation('/item/{id}/comment', {
+      segmentFirstGrouping: 1,
+      segmentSecondGrouping: 3
+    });
+    expect(endpoint).toBe('itemId');
+  });
+
+  it('should return itemIdThing', async () => {
+    const endpoint = endpointNameCalculation('/item/{id}/comment/thing', {
+      segmentFirstGrouping: 1,
+      segmentSecondGrouping: 3
+    });
+    expect(endpoint).toBe('itemIdThing');
+  });
+
+  it('should return itemIdThing', async () => {
+    const endpoint = endpointNameCalculation('/item/{id}/comment/thing', {
+      segmentFirstGrouping: 2,
+      segmentSecondGrouping: 3
+    });
+    expect(endpoint).toBe('itemCommentThing');
+  });
 });
 
-it('should return itemComment', async () => {
-  const endpoint = endpointNameCalculation('/item/{id}/comment/thing', {
-    segmentFirstGrouping: 2
+describe('2nd grouping only', () => {
+  it('should throw an error', async (done) => {
+    try {
+      endpointNameCalculation('/item/{id}/comment/thing', {
+        segmentSecondGrouping: 2
+      });
+      done('Should have thrown an error when only passing segmentSecondGrouping with no segmentFirstGrouping');
+    } catch (e) {
+      done();
+    }
   });
-  expect(endpoint).toBe('itemComment');
-});
-
-it('should return itemThing', async () => {
-  const endpoint = endpointNameCalculation('/item/{id}/comment/thing', {
-    segmentFirstGrouping: 3
-  });
-  expect(endpoint).toBe('itemThing');
-});
-
-it('should return itemId', async () => {
-  const endpoint = endpointNameCalculation('/item/{id}/comment/thing', {
-    segmentFirstGrouping: 1
-  });
-  expect(endpoint).toBe('itemId');
 });

--- a/src/lib/helpers/endpointNameCalculation.ts
+++ b/src/lib/helpers/endpointNameCalculation.ts
@@ -5,6 +5,11 @@ export default (fullPath: string, config: { segmentFirstGrouping?: number, segme
   if (segmentFirstGrouping === undefined && segmentSecondGrouping !== undefined) {
     throw new Error('You must provide segmentFirstGrouping when providing segmentSecondGrouping. segmentSecondGrouping found but segmentFirstGrouping is undefined');
   }
+  if (segmentFirstGrouping !== undefined && segmentSecondGrouping !== undefined) {
+    if (segmentFirstGrouping >= segmentSecondGrouping) {
+      throw new Error('When setting the segmentSecondGrouping it must be greater that the segmentFirstGrouping');
+    }
+  }
 
   // double check the 1st char is /
   if (fullPath[0] !== '/') {

--- a/src/lib/helpers/endpointNameCalculation.ts
+++ b/src/lib/helpers/endpointNameCalculation.ts
@@ -1,6 +1,11 @@
 import ucFirst from '@/lib/template/helpers/ucFirst';
 
-export default (fullPath: string, config: { segmentFirstGrouping?: number }): string => {
+export default (fullPath: string, config: { segmentFirstGrouping?: number, segmentSecondGrouping?: number }): string => {
+  const {segmentFirstGrouping, segmentSecondGrouping} = config;
+  if (segmentFirstGrouping === undefined && segmentSecondGrouping !== undefined) {
+    throw new Error('You must provide segmentFirstGrouping when providing segmentSecondGrouping. segmentSecondGrouping found but segmentFirstGrouping is undefined');
+  }
+
   // double check the 1st char is /
   if (fullPath[0] !== '/') {
     fullPath = '/' + fullPath;
@@ -9,10 +14,9 @@ export default (fullPath: string, config: { segmentFirstGrouping?: number }): st
   if (fullPath === '/') {
     return 'root';
   }
-  if (!config.segmentFirstGrouping) {
+  if (segmentFirstGrouping === undefined || segmentFirstGrouping === 0 && !segmentSecondGrouping) {
     return fullPath.split('/')[1];
   }
-  const {segmentFirstGrouping} = config;
   const segments = fullPath.split('/');
   // Get rid of the empty slot
   segments.shift();
@@ -21,6 +25,17 @@ export default (fullPath: string, config: { segmentFirstGrouping?: number }): st
     return fullPath.split('/')[1];
   }
 
+  if (!segmentSecondGrouping || segmentSecondGrouping && segmentSecondGrouping >= segments.length) {
+    return segments[0].replace(/{*}*/gm, '')
+      + ucFirst(segments[segmentFirstGrouping].replace(/{*}*/gm, ''));
+  }
+
+  if (segmentFirstGrouping === 0) {
+    return segments[0].replace(/{*}*/gm, '')
+      + ucFirst(segments[segmentSecondGrouping].replace(/{*}*/gm, ''));
+  }
+
   return segments[0].replace(/{*}*/gm, '')
-    + ucFirst(segments[segmentFirstGrouping].replace(/{*}*/gm, ''));
+    + ucFirst(segments[segmentFirstGrouping].replace(/{*}*/gm, ''))
+    + ucFirst(segments[segmentSecondGrouping].replace(/{*}*/gm, ''));
 };

--- a/src/lib/openapi/OpenAPIBundler.ts
+++ b/src/lib/openapi/OpenAPIBundler.ts
@@ -261,7 +261,8 @@ class OpenAPIBundler {
     const objects = apiObject.channels || apiObject.paths;
     for (const fullPath in objects) {
       const endpointName = endpointNameCalculation(fullPath, {
-        segmentFirstGrouping: config.segmentFirstGrouping || config.nodegenRc.segmentFirstGrouping
+        segmentFirstGrouping: config.segmentFirstGrouping || config.nodegenRc.segmentFirstGrouping,
+        segmentSecondGrouping: config.segmentSecondGrouping || config.nodegenRc.segmentSecondGrouping
       });
       const pathObject = objects[fullPath];
       if (includeOperationNameAction(endpointName, pathObject, config.nodegenRc)) {


### PR DESCRIPTION
turn this: 
/item/{id}/comment/thing

into this:
itemIdThing

low hanging fruit - adds a little more flexibility

src/lib/helpers/__tests__/endpointNameCalculation.ts shows more use cases.