### PR TITLE
FEAT: transform all 200-level responses

### DIFF
--- a/src/lib/helpers/extractOASchemaPathResponses.ts
+++ b/src/lib/helpers/extractOASchemaPathResponses.ts
@@ -1,5 +1,6 @@
 export default (input: any) => {
-  const successResponse = Object.entries(input).find(([code, reponse]) => /2\d\d/.test(code));
+  const successResponse = Object.entries(input).find(([statusCode, reponse]) => /2\d\d/.test(statusCode));
+
   if (!successResponse?.[1]) {
     return {};
   }

--- a/src/lib/helpers/extractOASchemaPathResponses.ts
+++ b/src/lib/helpers/extractOASchemaPathResponses.ts
@@ -1,18 +1,23 @@
 export default (input: any) => {
-  if (input['200']) {
-    if (input['200'].schema) {
-      // we are oa2
-      return input['200'].schema;
-    } else {
-      // we are oa3
-      if (input['200'].content && input['200'].content['application/json']) {
-        if (input['200'].content['application/json'].schema) {
-          return input['200'].content['application/json'].schema;
-        }
+  const successResponse = Object.entries(input).find(([code, reponse]) => /2\d\d/.test(code));
+  if (!successResponse?.[1]) {
+    return {};
+  }
+
+  const [code, response] = successResponse as [string, { schema: any, content: any }];
+
+  if (response.schema) {
+    // we are oa2
+    return response.schema;
+  } else {
+    // we are oa3
+    if (response.content && response.content['application/json']) {
+      if (response.content['application/json'].schema) {
+        return response.content['application/json'].schema;
       }
     }
   }
   // We also check if the input contains any valid OA schema by looking for type or properties in the provided object
   // The typical use case here if for async api payloads
-  return (input && (input.type || input.properties)) ? input : {};
+  return (input?.type || input?.properties) ? input : {};
 };


### PR DESCRIPTION
Extract the first 200-level response (as opposed to only 200), and use that for validation.

Use case: POST that returns the newly created entity, or a `runningJobId` (for example).