### PR TITLE
Enh/move templates to helper

### DIFF
--- a/src/__tests__/asyncapi_full.ts
+++ b/src/__tests__/asyncapi_full.ts
@@ -1,11 +1,10 @@
 import openapiNodegen from '@/generateIt';
 import { fdir } from 'fdir';
 import path from 'path';
-import { clearTestServer, yamlToJson } from './helpers';
+import { clearTestServer, templates, yamlToJson } from './helpers';
 
 const serverDir = 'test_asyncapi';
 const testServerPath = path.join(process.cwd(), serverDir);
-export const tplUrl = 'https://github.com/acrontum/generate-it-asyncapi-rabbitmq.git';
 
 describe('e2e testing', () => {
   beforeAll(() => {
@@ -25,7 +24,7 @@ describe('e2e testing', () => {
       mockServer: false,
       swaggerFilePath: ymlPath,
       targetDir: testServerPath,
-      template: tplUrl,
+      template: templates.asyncapiRabbitmqGit,
     });
 
     expect(wasGenerated).toBe(true);

--- a/src/__tests__/helpers/index.ts
+++ b/src/__tests__/helpers/index.ts
@@ -1,8 +1,12 @@
 import fs from 'fs-extra';
 import path from 'path';
 
-export const tplUrl = 'https://github.com/acrontum/openapi-nodegen-typescript-server.git';
-export const tplClientServer = 'https://github.com/acrontum/openapi-nodegen-typescript-server-client.git';
+export const templates = {
+  tsServerGit: 'https://github.com/acrontum/openapi-nodegen-typescript-server.git',
+  serverClientGit:'https://github.com/acrontum/openapi-nodegen-typescript-server-client.git',
+  asyncapiRabbitmqGit: 'https://github.com/acrontum/generate-it-asyncapi-rabbitmq.git',
+};
+
 export const clearTestServer = (dir: string = 'test_server') => {
   // return;
   const names = fs.readdirSync(path.join(process.cwd(), dir));

--- a/src/__tests__/helpers/index.ts
+++ b/src/__tests__/helpers/index.ts
@@ -3,19 +3,23 @@ import path from 'path';
 
 export const templates = {
   tsServerGit: 'https://github.com/acrontum/openapi-nodegen-typescript-server.git',
-  serverClientGit:'https://github.com/acrontum/openapi-nodegen-typescript-server-client.git',
+  serverClientGit: 'https://github.com/acrontum/openapi-nodegen-typescript-server-client.git',
   asyncapiRabbitmqGit: 'https://github.com/acrontum/generate-it-asyncapi-rabbitmq.git',
 };
 
 export const clearTestServer = (dir: string = 'test_server') => {
-  // return;
-  const names = fs.readdirSync(path.join(process.cwd(), dir));
+  const root = path.join(process.cwd(), dir);
+  if (!fs.existsSync(root)) {
+    return;
+  }
+
+  const names = fs.readdirSync(root);
   for (let i = 0; i < names.length; ++i) {
     if (names[i] !== '.openapi-nodegen') {
-      fs.removeSync(path.join(process.cwd(), dir, names[i]));
+      fs.removeSync(path.join(root, names[i]));
     }
   }
-  const compare = path.join(process.cwd(), dir, '/.openapi-nodegen/cache');
+  const compare = path.join(root, '/.openapi-nodegen/cache');
   if (fs.pathExistsSync(compare)) {
     fs.removeSync(compare);
   }

--- a/src/__tests__/openapiNodegen_1stSegmentGrouping.ts
+++ b/src/__tests__/openapiNodegen_1stSegmentGrouping.ts
@@ -1,16 +1,18 @@
-import fs from 'fs-extra';
-import path from 'path';
 import openapiNodegen from '@/generateIt';
+import fs from 'fs-extra';
 import hasha from 'hasha';
-import { tplUrl, clearTestServer } from './helpers';
+import path from 'path';
+import { clearTestServer, templates } from './helpers';
 
 jest.setTimeout(60 * 1000); // in milliseconds
+
 const testServerPath = path.join(process.cwd(), 'test_server');
 
 describe('e2e testing', () => {
   beforeAll(() => {
     clearTestServer();
   });
+
   afterAll(() => {
     clearTestServer();
   });
@@ -25,7 +27,7 @@ describe('e2e testing', () => {
         segmentFirstGrouping: 1,
         swaggerFilePath: ymlPath,
         targetDir: testServerPath,
-        template: tplUrl,
+        template: templates.tsServerGit,
         variables: {
           name: 'Generate-it Typescript Server'
         }
@@ -48,7 +50,7 @@ describe('e2e testing', () => {
         segmentFirstGrouping: 1,
         swaggerFilePath: ymlPath,
         targetDir: testServerPath,
-        template: tplUrl,
+        template: templates.tsServerGit,
       });
       done();
     } catch (e) {

--- a/src/__tests__/openapiNodegen_full.ts
+++ b/src/__tests__/openapiNodegen_full.ts
@@ -1,16 +1,18 @@
-import fs from 'fs-extra';
-import path from 'path';
 import openapiNodegen from '@/generateIt';
+import fs from 'fs-extra';
 import hasha from 'hasha';
-import { tplUrl, clearTestServer } from './helpers';
+import path from 'path';
+import { clearTestServer, templates } from './helpers';
 
 jest.setTimeout(60 * 1000); // in milliseconds
+
 const testServerPath = path.join(process.cwd(), 'test_server');
 
 describe('e2e testing', () => {
   beforeAll(() => {
     clearTestServer();
   });
+
   afterAll(() => {
     clearTestServer();
   });
@@ -24,7 +26,7 @@ describe('e2e testing', () => {
         mockServer: true,
         swaggerFilePath: ymlPath,
         targetDir: testServerPath,
-        template: tplUrl,
+        template: templates.tsServerGit,
         variables: {
           name: 'Generate-it Typescript Server'
         }
@@ -46,7 +48,7 @@ describe('e2e testing', () => {
         mockServer: true,
         swaggerFilePath: ymlPath,
         targetDir: testServerPath,
-        template: tplUrl,
+        template: templates.tsServerGit,
       });
       done();
     } catch (e) {

--- a/src/__tests__/openapiNodegen_git.ts
+++ b/src/__tests__/openapiNodegen_git.ts
@@ -4,7 +4,7 @@ import { clearTestServer, templates } from './helpers';
 
 jest.setTimeout(60 * 1000); // in milliseconds
 
-const testServerName = 'test_server_2';
+const testServerName = 'test_server';
 const testServerPath = path.join(process.cwd(), testServerName);
 
 describe('e2e testing', () => {

--- a/src/__tests__/openapiNodegen_git.ts
+++ b/src/__tests__/openapiNodegen_git.ts
@@ -1,19 +1,19 @@
-import fs from 'fs-extra';
-import path from 'path';
 import openapiNodegen from '@/generateIt';
+import path from 'path';
+import { clearTestServer, templates } from './helpers';
 
 jest.setTimeout(60 * 1000); // in milliseconds
 
 const testServerName = 'test_server_2';
 const testServerPath = path.join(process.cwd(), testServerName);
-export const tplUrl = 'https://github.com/acrontum/openapi-nodegen-typescript-server.git';
 
 describe('e2e testing', () => {
   beforeAll(() => {
-    fs.removeSync(testServerName);
+    clearTestServer(testServerName);
   });
+
   afterAll(() => {
-    fs.removeSync(testServerName);
+    clearTestServer(testServerName);
   });
 
   it('Should build without error', async (done) => {
@@ -25,7 +25,7 @@ describe('e2e testing', () => {
         mockServer: true,
         swaggerFilePath: ymlPath,
         targetDir: testServerPath,
-        template: tplUrl,
+        template: templates.tsServerGit,
       });
       done();
     } catch (e) {

--- a/src/__tests__/openapiNodegen_oa3.ts
+++ b/src/__tests__/openapiNodegen_oa3.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import openapiNodegen from '@/generateIt';
 import hasha from 'hasha';
-import { clearTestServer, tplUrl } from '@/__tests__/helpers';
+import { clearTestServer, templates } from '@/__tests__/helpers';
 
 jest.setTimeout(60 * 1000); // in milliseconds
 
@@ -11,6 +11,7 @@ describe('e2e testing', () => {
   beforeAll(() => {
     clearTestServer();
   });
+
   afterAll(() => {
     clearTestServer();
   });
@@ -24,7 +25,7 @@ describe('e2e testing', () => {
         mockServer: true,
         swaggerFilePath: ymlPath,
         targetDir: testServerPath,
-        template: tplUrl,
+        template: templates.tsServerGit,
       });
       done();
     } catch (e) {

--- a/src/__tests__/openapi_serverClient.ts
+++ b/src/__tests__/openapi_serverClient.ts
@@ -1,9 +1,10 @@
 import fs from 'fs';
 import path from 'path';
 import openapiNodegen from '@/generateIt';
-import { tplUrl, tplClientServer, clearTestServer } from './helpers';
+import { templates, clearTestServer } from './helpers';
 
 jest.setTimeout(60 * 1000); // in milliseconds
+
 const dirName = 'test_server_client';
 const testServerPath = path.join(process.cwd(), dirName);
 const testClientPath = path.join(testServerPath, 'src/services/openweathermap');
@@ -13,6 +14,7 @@ describe('e2e testing', () => {
   beforeAll(() => {
     clearTestServer(dirName);
   });
+
   afterAll(() => {
     clearTestServer(dirName);
   });
@@ -25,7 +27,7 @@ describe('e2e testing', () => {
         mockServer: false,
         swaggerFilePath: ymlPath,
         targetDir: testServerPath,
-        template: tplUrl,
+        template: templates.tsServerGit,
       });
       done();
     } catch (e) {
@@ -41,13 +43,14 @@ describe('e2e testing', () => {
         mockServer: false,
         swaggerFilePath: ymlPath,
         targetDir: testClientPath,
-        template: tplClientServer,
+        template: templates.serverClientGit,
       });
       done();
     } catch (e) {
       done(e);
     }
   });
+
   it('should edit the client, regen and see the edit still present', async () => {
     const checkPath = path.join(testClientPath, 'lib/HttpService.ts');
     fs.writeFileSync(checkPath, '//', 'utf8');
@@ -57,7 +60,7 @@ describe('e2e testing', () => {
       mockServer: false,
       swaggerFilePath: ymlPath,
       targetDir: testClientPath,
-      template: tplClientServer,
+      template: templates.serverClientGit,
     });
     const templateStr = fs.readFileSync(checkPath).toString('utf8');
     expect(templateStr).toBe('//');


### PR DESCRIPTION
Move some hardcoded strings around in tests so that it's easier to change when manually testing non-master branches