### PR TITLE
fix: this checks to ensure we have a truthy value before continuing. …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "generate-it",
-  "version": "5.20.1",
+  "version": "5.20.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generate-it",
-  "version": "5.20.1",
+  "version": "5.20.2",
   "description": "Generate it, socket and html consumers and clients from yml files (openapi/asyncapi)",
   "author": "Acrontum GmbH",
   "license": "MIT",

--- a/src/lib/template/helpers/paramsOutputReducer.ts
+++ b/src/lib/template/helpers/paramsOutputReducer.ts
@@ -3,6 +3,9 @@ import OaToJs from '@/lib/helpers/OaToJs';
 import OaToJsToJs from '@/lib/helpers/OaToJsToJs';
 
 export default (responses: any) => {
+  if (!responses) {
+    return responses;
+  }
   const schema = extractOASchemaPathResponses(JSON.parse(JSON.stringify(responses)));
   const a = OaToJs.oaToJsType(schema);
   if (a && a.required) {


### PR DESCRIPTION
…Was throwing errors request-definitions were empty