### PR TITLE
Allow local template folder

### DIFF
--- a/src/commander.ts
+++ b/src/commander.ts
@@ -44,7 +44,7 @@ export default (inputArgsArray: string[]): CommanderResponse => {
     .option('-$, --variables [value]', 'Array of variables to pass to the templates, eg "-$ httpLibImportStr=@/services/HttpService -$ apikey=321654987"', commanderCollectArray, {})
     .option('-v, --verbose', 'Outputs verbose logging')
     .option('--very-verbose', 'Outputs very verbose logging')
-    .option('-y, --yes', 'Assumes yes to any questions prompted by the tool. If marked yes we assume you know what you are doing and know the nodegenDir will be rewritten')
+    .option('-y, --yes', 'Assumes yes to any questions prompted by the tool. If marked yes we assume you know what you are doing and know the nodegenDir will be rewritten', true)
     .parse(inputArgsArray);
 
   if (!swaggerFile) {

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -44,7 +44,7 @@ export default (inputArgsArray: string[]): CommanderResponse => {
     .option('-$, --variables [value]', 'Array of variables to pass to the templates, eg "-$ httpLibImportStr=@/services/HttpService -$ apikey=321654987"', commanderCollectArray, {})
     .option('-v, --verbose', 'Outputs verbose logging')
     .option('--very-verbose', 'Outputs very verbose logging')
-    .option('-y, --yes', 'Assumes yes to any questions prompted by the tool. If marked yes we assume you know what you are doing and know the nodegenDir will be rewritten', true)
+    .option('-y, --yes', 'Assumes yes to any questions prompted by the tool. If marked yes we assume you know what you are doing and know the nodegenDir will be rewritten')
     .parse(inputArgsArray);
 
   if (!swaggerFile) {

--- a/src/lib/template/__tests__/TemplateFetch.ts
+++ b/src/lib/template/__tests__/TemplateFetch.ts
@@ -51,3 +51,26 @@ describe('semver check', () => {
     expect(TemplateFetch.isSemVer('a')).toBe(false);
   });
 });
+
+describe('local folder structure', () => {
+  const srcRoot = path.join(process.cwd(), '/bob');
+  const testDir = path.join('one', 'two', 'three');
+  const src = path.join(srcRoot, testDir);
+  const dest = './.bob-out';
+
+  afterAll(() => {
+    fs.removeSync(srcRoot);
+    fs.removeSync(dest);
+  });
+
+  it('accepts a local folder', async () => {
+    fs.ensureDirSync(src);
+    fs.writeJsonSync(path.join(src, 'test.json'), { hello: 'world' });
+
+    const cacheDirectory = TemplateFetch.calculateLocalDirectoryFromUrl(srcRoot, dest);
+    await TemplateFetch.resolveTemplateType(srcRoot, dest, false);
+    const testFile = path.join(process.cwd(), cacheDirectory, testDir, 'test.json');
+    expect(fs.existsSync(testFile)).toBe(true);
+    expect(require(testFile).hello).toBe('world');
+  });
+});


### PR DESCRIPTION
Re-petitioning for this feature.

Opened a while back, but wasn't really necessary. Still isn't, but makes local dev much simpler.

To address the concern about encouraging unshared code - people can do that by setting up private template repos anyway, so we're not really solving that issue anyway, but maybe we could just leave this sneak feature out of the docs so that at least people will not jump to local templates by default.

open for discussion - I've been using this locally for a while, but would save me a rebase and rebuild each time in the future, so I'm a bit biased here for sure