### PR TITLE
replace walk with faster walk; fix file ignore to properly skip targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,9 @@ coverage/
 jest/
 .DS_Store
 npm-debug.log
+
+# test junk - ignore all, then unignore nodegen
+test_asyncapi/*
+!test_asyncapi/*/.openapi-nodegen
+test_server*/*
+!test_server*/*/.openapi-nodegen

--- a/package-lock.json
+++ b/package-lock.json
@@ -741,6 +741,11 @@
         "unicode-trie": "^0.3.0"
       }
     },
+    "@root/walk": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@root/walk/-/walk-1.1.0.tgz",
+      "integrity": "sha512-FfXPAta9u2dBuaXhPRawBcijNC9rmKVApmbi6lIZyg36VR/7L02ytxoY5K/14PJlHqiBUoYII73cTlekdKTUOw=="
+    },
     "@sinonjs/commons": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -928,15 +928,6 @@
         "@types/node": "*"
       }
     },
-    "@types/walk": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@types/walk/-/walk-2.3.0.tgz",
-      "integrity": "sha512-I1w1RJW5kowe7JnekvVTSD/Lek8WK0N/Fz80n9Chnb5jYo+mne4tDthgCAV/Fo1tym9m8W6stfsJQvjRMpOHgw==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/yamljs": {
       "version": "0.2.31",
       "resolved": "https://registry.npmjs.org/@types/yamljs/-/yamljs-0.2.31.tgz",
@@ -2646,11 +2637,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
       "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
-    },
-    "foreachasync": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
-      "integrity": "sha1-VQKYfchxS+M5IJfzLgBxyd7gfPY="
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -7034,14 +7020,6 @@
         "domexception": "^1.0.1",
         "webidl-conversions": "^4.0.2",
         "xml-name-validator": "^3.0.0"
-      }
-    },
-    "walk": {
-      "version": "2.3.14",
-      "resolved": "https://registry.npmjs.org/walk/-/walk-2.3.14.tgz",
-      "integrity": "sha512-5skcWAUmySj6hkBdH6B6+3ddMjVQYH5Qy9QGbPmN8kVmLteXk+yVXg+yfk1nbX30EYakahLrr8iPcCxJQSCBeg==",
-      "requires": {
-        "foreachasync": "^3.0.0"
       }
     },
     "walker": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "generate-it"
   ],
   "dependencies": {
+    "@root/walk": "^1.1.0",
     "colors": "^1.4.0",
     "commander": "^5.1.0",
     "compare-versions": "^3.6.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "semver": "^7.3.4",
     "text-file-diff": "^1.1.2",
     "uglify-es": "^3.3.9",
-    "walk": "^2.3.14",
     "word-wrap": "^1.2.3"
   },
   "devDependencies": {
@@ -70,7 +69,6 @@
     "@types/nunjucks": "^3.1.3",
     "@types/prettier": "^2.1.6",
     "@types/semver": "^7.3.4",
-    "@types/walk": "^2.3.0",
     "@types/yamljs": "^0.2.31",
     "@zerollup/ts-transform-paths": "^1.7.18",
     "codecov": "^3.8.1",

--- a/src/lib/helpers/__tests__/isFileToIngore.ts
+++ b/src/lib/helpers/__tests__/isFileToIngore.ts
@@ -1,27 +1,25 @@
 import isFileToIngore from '@/lib/helpers/isFileToIngore';
 
-describe('Should no allow directories on black list, eg git idea vscode, even as a file', () => {
-  it('should no allow git paths', () => {
+describe('Should not allow directories on black list, eg git idea vscode, even as a file', () => {
+  it('should skip .git, node_modules, and editor files', () => {
     expect(isFileToIngore('som/dir/.git', 'config')).toBe(true);
-  });
-  it('should no allow idea paths', () => {
     expect(isFileToIngore('som/dir/.idea', 'workspace')).toBe(true);
-  });
-  it('should no allow vscode paths', () => {
     expect(isFileToIngore('som/dir/.vscode', 'workspace')).toBe(true);
+    expect(isFileToIngore('som/dir/vscode', '.vscode')).toBe(true);
+    expect(isFileToIngore('som/dir/.vscode/blah', 'workspace')).toBe(true);
+    expect(isFileToIngore('som/dir/node_modules/blah', 'workspace')).toBe(true);
+    expect(isFileToIngore('som/dir/node_modules', 'workspace')).toBe(true);
+    expect(isFileToIngore('som/dir/node_modules/', 'workspace')).toBe(true);
   });
 
-  it('should no allow vscode paths', () => {
-    expect(isFileToIngore('som/dir/vscode', '.vscode')).toBe(true);
+  it('should match exactly', () => {
+    expect(isFileToIngore('som/dir/.gitignore', 'config')).toBe(false);
   });
 });
 
 describe('Should other directories in and .njk files', () => {
   it('should allow http paths', () => {
     expect(isFileToIngore('som/dir/http', 'config')).toBe(false);
-  });
-
-  it('should allow http paths', () => {
     expect(isFileToIngore('som/dir/http', '___op.njk')).toBe(false);
   });
 });

--- a/src/lib/helpers/isFileToIngore.ts
+++ b/src/lib/helpers/isFileToIngore.ts
@@ -1,12 +1,3 @@
 export default (dir: string, filename: string) => {
-  const prohibited = ['.git', '.idea', '.vscode'];
-  for (let i = 0; i < prohibited.length; i++) {
-    if (dir.indexOf(prohibited[i]) !== -1) {
-      return true;
-    }
-    if (filename === prohibited[i]) {
-      return true;
-    }
-  }
-  return false;
+  return /(\.idea|\.git|\.vscode|node_modules)\b/.test(`${dir}/${filename}`);
 };

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,1 @@
+declare module '@root/walk';


### PR DESCRIPTION
started by adding ignored folders to the walker, but it stopped working properly. 
looked into the readme for instructions and basically pointed to this way better walk, so replaced it, fixed and wired up the ignore checker.

 - added test junk to gitignore
 - new walker doesn't have types, so just yolo in an any module
 - cleaned up and added some more folder pattern checks
 - result is significantly faster, which is nice for tests too