### PR TITLE
add build folders to default ignore

### DIFF
--- a/src/lib/helpers/isFileToIngore.ts
+++ b/src/lib/helpers/isFileToIngore.ts
@@ -1,3 +1,3 @@
 export default (dir: string, filename: string) => {
-  return /(\.idea|\.git|\.vscode|node_modules)\b/.test(`${dir}/${filename}`);
+  return /(\.idea|\.git|\.vscode|node_modules|build|dist)\b/.test(`${dir}/${filename}`);
 };


### PR DESCRIPTION
might make sense to add some configuration options here, but just added common build outputs to the default ignore files