### PR TITLE
Bug/file and import naming mismatch

### DIFF
--- a/src/interfaces/ConfigExtendedBase.ts
+++ b/src/interfaces/ConfigExtendedBase.ts
@@ -3,10 +3,13 @@ import { NodegenRc } from '@/interfaces/NodegenRc';
 import { Package } from '@/interfaces/Package';
 import { Swagger } from '@/interfaces/Swagger';
 
+// TODO
+export type AsyncApi = Record<string, any>;
+
 export interface ConfigExtendedBase extends Config {
   nodegenRc?: NodegenRc;
   interfaceStyle?: string;
   templates?: string;
-  swagger?: Swagger;
+  swagger?: Swagger | AsyncApi;
   package?: Package;
 }

--- a/src/lib/helpers/NamingUtils.ts
+++ b/src/lib/helpers/NamingUtils.ts
@@ -18,7 +18,7 @@ class NamingUtils {
       suffix += 's';
     }
     if (!FUNCS_DIRS.includes(subDirSplit[subDirSplit.length - 1])) {
-      operation = operation.charAt(0).toUpperCase() + operation.substring(1);
+      operation = operation.charAt(0).toUpperCase() + _.camelCase(operation.substring(1));
     }
 
     return operation + suffix + '.' + ext;

--- a/src/lib/helpers/__tests__/namingUtils.generateOperationSuffix.ts
+++ b/src/lib/helpers/__tests__/namingUtils.generateOperationSuffix.ts
@@ -13,3 +13,9 @@ it('should return customerRoutes.ts', () => {
     generateOperationSuffix('src/http/nodegen/routes', 'customer', 'ts'),
   ).toBe('customerRoutes.ts');
 });
+
+it('should return B2DDomainMock.ts', () => {
+  expect(
+    generateOperationSuffix('src/domains/__mocks__', 'b2d', 'ts'),
+  ).toBe('B2DDomainMock.ts');
+});


### PR DESCRIPTION
fix strange edge case:

```yaml
#...
paths:
  /b2d/something: #...
```

caused domain file created as `B2dDomain(Mock).ts` but imports were 
```
import { B2DDomainInterface } from '@/http/nodegen/domainInterfaces/B2DDomainInterface';
import B2DDomainMock from './__mocks__/B2DDomainMock';
```

now the files are named using the same method (somewhat) that gets the import name