### PR TITLE
Update namer method to always camelcase

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1437,11 +1437,6 @@
         "node-int64": "^0.4.0"
       }
     },
-    "btoa": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
-      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g=="
-    },
     "buffer-equal": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
@@ -2502,11 +2497,6 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
-    "faker": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/faker/-/faker-4.1.0.tgz",
-      "integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8="
-    },
     "falafel": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/falafel/-/falafel-2.2.4.tgz",
@@ -2717,23 +2707,6 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
-    },
-    "generate-it-mockers": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/generate-it-mockers/-/generate-it-mockers-1.0.4.tgz",
-      "integrity": "sha512-gU26Euz70jz133vVkKzUW9dNZPzSchwJFjd2b2k+7EvDnzQB7wZOZDzza0TSXyr27c8UgY4l0+SOnQzQSJh0tQ==",
-      "requires": {
-        "btoa": "^1.2.1",
-        "faker": "^4.1.0",
-        "uuid": "^7.0.3"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-          "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
-        }
-      }
     },
     "gensync": {
       "version": "1.0.0-beta.1",
@@ -6848,9 +6821,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
       "dev": true
     },
     "typical": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1437,6 +1437,11 @@
         "node-int64": "^0.4.0"
       }
     },
+    "btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g=="
+    },
     "buffer-equal": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
@@ -2497,6 +2502,11 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
+    "faker": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-4.1.0.tgz",
+      "integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8="
+    },
     "falafel": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/falafel/-/falafel-2.2.4.tgz",
@@ -2707,6 +2717,23 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
+    },
+    "generate-it-mockers": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/generate-it-mockers/-/generate-it-mockers-1.0.5.tgz",
+      "integrity": "sha512-G30nEiyRhN9etCRE+adxK4Xkn3NEy/kimuAuvQR9rtJVzFnaxxp0BIOZQKsMHC5k1jpTh2v6suDdKGPo56WB4Q==",
+      "requires": {
+        "btoa": "^1.2.1",
+        "faker": "^4.1.0",
+        "uuid": "^7.0.3"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+          "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
+        }
+      }
     },
     "gensync": {
       "version": "1.0.0-beta.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "compare-versions": "^3.6.0",
     "deepmerge": "^4.2.2",
     "fs-extra": "^9.0.1",
-    "generate-it-mockers": "^1.0.4",
+    "generate-it-mockers": "^1.0.5",
     "inquirer": "^7.3.3",
     "js-yaml": "^3.14.1",
     "json-schema-ref-parser": "^9.0.6",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,6 @@
     "ts-jest": "^25.4.0",
     "tslint": "^6.1.3",
     "ttypescript": "^1.5.10",
-    "typescript": "^3.9.7"
+    "typescript": "^4.1.3"
   }
 }

--- a/src/lib/helpers/NamingUtils.ts
+++ b/src/lib/helpers/NamingUtils.ts
@@ -17,8 +17,9 @@ class NamingUtils {
     if (SHOULD_PLURAL.includes(suffix)) {
       suffix += 's';
     }
+    operation = _.camelCase(operation);
     if (!FUNCS_DIRS.includes(subDirSplit[subDirSplit.length - 1])) {
-      operation = operation.charAt(0).toUpperCase() + _.camelCase(operation.substring(1));
+      operation = operation.charAt(0).toUpperCase() + operation.substring(1);
     }
 
     return operation + suffix + '.' + ext;


### PR DESCRIPTION
Since the operation is almost always already camelCase, this should only affect the edge case (something like `x2y`)