### PR TITLE
Fix hanging tests which use mockers

### DIFF
--- a/src/lib/template/helpers/mockOutput.ts
+++ b/src/lib/template/helpers/mockOutput.ts
@@ -1,13 +1,19 @@
 import extractOASchemaPathResponses from '@/lib/helpers/extractOASchemaPathResponses';
 
-const dummyGenerate = (schema: any) => {
-  return schema ? 'return mockItGenerator(' + JSON.stringify(schema) + ')' : undefined;
+const dummyGenerate = (schema: any, path: any) => {
+  if (schema) {
+    if (path['x-passResponse']) {
+      return `res.end(JSON.stringify(mockItGenerator(${JSON.stringify(schema)}))); return Promise.resolve(null);`;
+    } else {
+      return `return mockItGenerator(${JSON.stringify(schema)})`;
+    }
+  }
 };
 
 export default (path: any, mockServer: boolean) => {
   if (mockServer) {
     return (path && path.responses) ?
-      dummyGenerate(extractOASchemaPathResponses(path.responses)) :
+      dummyGenerate(extractOASchemaPathResponses(path.responses), path) :
       undefined;
   } else {
     return 'return {}';


### PR DESCRIPTION
if schema specifies `x-passRequest` then the mocks would hang without calling `res.end`.

