### PR TITLE
feat: when the git folder is nuked or contains changes it will clone …

### DIFF
--- a/src/lib/template/TemplateFetch.ts
+++ b/src/lib/template/TemplateFetch.ts
@@ -121,9 +121,13 @@ class TemplateFetchURL {
         await this.gitClone(urlParts.url, cacheDirectory, urlParts.b);
       }
     } catch (e) {
-      console.error('Could not clone or pull the given git repository!');
+      console.error('Could not clone or pull the given git repository, clearing and cloning from fresh.');
       this.cleanSingleCacheDir(cacheDirectory);
-      throw e;
+      try {
+        await this.gitClone(urlParts.url, cacheDirectory, urlParts.b);
+      } catch (e) {
+        throw e;
+      }
     }
     return cacheDirectory;
   }
@@ -164,8 +168,8 @@ class TemplateFetchURL {
       console.log(
         `
 The` +
-          `generate-it`.bold +
-          `version must be greater or equal to the semver of the template tag but within the same major version.
+        `generate-it`.bold +
+        `version must be greater or equal to the semver of the template tag but within the same major version.
 You are currently using the following version:
 generate-it: ${pkVersion}
 template version tag: ${tplTag}


### PR DESCRIPTION
…from fresh to prevent scripts from just stopping

fixes: https://github.com/acrontum/generate-it/issues/75

basically git throws an error, the generate-it just stops. When it stops it is really annoying when generating many from scripts.

this will try, catch then try again.. if caught again it will stop.