### PR TITLE
ENH: disallow null in body params with x-nullable (oa2) or nullable (oa3)

### DIFF
--- a/src/lib/helpers/SwaggerUtils.ts
+++ b/src/lib/helpers/SwaggerUtils.ts
@@ -49,7 +49,7 @@ class SwaggerUtils {
     const isRequired = (options.requiredFields && options.requiredFields.includes(param.name)) || param.required;
     const type = param.type || param.schema.type;
 
-    const nullable = paramTypeKey === ParamTypeKey.body ? '.allow(null)' : '';
+    const nullable = (paramTypeKey === ParamTypeKey.body && param['x-nullable'] !== false && param.nullable !== false) ? '.allow(null)' : '';
     const validationTrailer = (isRequired && !options.isFromArray ? '.required()' : nullable) + (!options.isFromArray ? ',' : '');
 
     if (['string', 'number', 'integer', 'boolean'].includes(type)) {


### PR DESCRIPTION
nullable is supported in oa3, oa2 solution recommends x-nullable

https://swagger.io/docs/specification/data-models/data-types/#null
https://jane.readthedocs.io/en/latest/tips/nullable.html

the problem:
body params are assumed to be nullable, which means a patch can unset a field even if it has min-length validation

solution:
```yaml
# model.yml
type: object
properties:
  name:
    type: string
    nullable: false # oa3
    x-nullable: false # oa2
```

alternatively, making a new model for post/patch/get if the params differ